### PR TITLE
fix Invalid Amount bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5198,11 +5198,6 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
-    "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",

--- a/src/components/vote/modal/stakeModal.jsx
+++ b/src/components/vote/modal/stakeModal.jsx
@@ -436,7 +436,7 @@ const StakeWithdrawModal = ({
   };
 
   const onStake = () => {
-    if (inputAmount <= 0 || inputAmount > balance) {
+    if (parseFloat(inputAmount)  <= 0 || parseFloat(inputAmount)  > parseFloat(balance) ) {
       setError("Invalid Amount!");
       return;
     }
@@ -457,7 +457,7 @@ const StakeWithdrawModal = ({
   };
 
   const onUnstake = () => {
-    if (inputAmount < 0 || inputAmount > staked) {
+    if (parseFloat(inputAmount) < 0 || parseFloat(inputAmount) > parseFloat(staked)) {
       setError("Invalid Amount!");
       return;
     }
@@ -611,90 +611,90 @@ const StakeWithdrawModal = ({
                 </div>
               </>
             ) : (
-              <>
-                <div className={classes.desktopStakeWithdrawAvailableWrapper}>
-                  <Typography
-                    className={classes.stakeWithdrawAvailableText}
-                    variant={"h6"}
-                  >
-                    Currently Staked: {staked} {isLegacy ? "YFL" : "yYFL"}
-                    {!isLegacy && (
-                      <Typography
-                        className={classes.stakeWithdrawAvailableValue}
-                        variant={"h6"}
-                      >
-                        ≈ {(staked * price).toFixed(3).toLocaleString()} YFL
-                      </Typography>
-                    )}
-                  </Typography>
-                  <Button
-                    className={classes.stakeWithdrawMaxButton}
-                    variant="contained"
-                    onClick={() => {
-                      onMax();
-                    }}
-                  >
-                    MAX
+                <>
+                  <div className={classes.desktopStakeWithdrawAvailableWrapper}>
+                    <Typography
+                      className={classes.stakeWithdrawAvailableText}
+                      variant={"h6"}
+                    >
+                      Currently Staked: {staked} {isLegacy ? "YFL" : "yYFL"}
+                      {!isLegacy && (
+                        <Typography
+                          className={classes.stakeWithdrawAvailableValue}
+                          variant={"h6"}
+                        >
+                          ≈ {(staked * price).toFixed(3).toLocaleString()} YFL
+                        </Typography>
+                      )}
+                    </Typography>
+                    <Button
+                      className={classes.stakeWithdrawMaxButton}
+                      variant="contained"
+                      onClick={() => {
+                        onMax();
+                      }}
+                    >
+                      MAX
                   </Button>
-                </div>
-                <div className={classes.mobileStakeWithdrawAvailableWrapper}>
-                  <Typography
-                    className={classes.stakeWithdrawAvailableText}
-                    variant={"h6"}
-                  >
-                    Staked: {staked} {isLegacy ? "YFL" : "yYFL"}
-                    {!isLegacy && (
-                      <Typography
-                        className={classes.stakeWithdrawAvailableValue}
-                        variant={"h6"}
-                      >
-                        ≈ {(staked * price).toFixed(3).toLocaleString()} YFL
-                      </Typography>
-                    )}
-                  </Typography>
-                  <Button
-                    className={classes.stakeWithdrawMaxButton}
-                    variant="contained"
-                    onClick={() => {
-                      onMax();
-                    }}
-                  >
-                    MAX
+                  </div>
+                  <div className={classes.mobileStakeWithdrawAvailableWrapper}>
+                    <Typography
+                      className={classes.stakeWithdrawAvailableText}
+                      variant={"h6"}
+                    >
+                      Staked: {staked} {isLegacy ? "YFL" : "yYFL"}
+                      {!isLegacy && (
+                        <Typography
+                          className={classes.stakeWithdrawAvailableValue}
+                          variant={"h6"}
+                        >
+                          ≈ {(staked * price).toFixed(3).toLocaleString()} YFL
+                        </Typography>
+                      )}
+                    </Typography>
+                    <Button
+                      className={classes.stakeWithdrawMaxButton}
+                      variant="contained"
+                      onClick={() => {
+                        onMax();
+                      }}
+                    >
+                      MAX
                   </Button>
-                </div>
-                <div className={classes.stakeWithdrawInputValueWrapper}>
-                  <InputBase
-                    classes={{
-                      root: classes.stakeWithdrawBoxRoot,
-                      input: classes.stakeWithdrawInputBoxInput,
-                    }}
-                    onChange={(ev) => {
-                      setInputAmount(ev.target.value);
-                    }}
-                    value={inputAmount}
-                    placeholder="Enter amount you want to unstake"
-                    type="number"
-                    autoFocus
-                  />
-                  {error && (
-                    <span className={classes.stakeWithdrawInputError}>
-                      {error}
-                    </span>
-                  )}
-                </div>
-                <div className={classes.stakeWithdrawPreviewWrapper}>
-                  <Typography
-                    className={classes.stakeWithdrawPreviewHeader}
-                    variant={"h6"}
-                  >
-                    You'll receive
+                  </div>
+                  <div className={classes.stakeWithdrawInputValueWrapper}>
+                    <InputBase
+                      classes={{
+                        root: classes.stakeWithdrawBoxRoot,
+                        input: classes.stakeWithdrawInputBoxInput,
+                      }}
+                      onChange={(ev) => {
+                        setInputAmount(ev.target.value);
+                      }}
+                      value={inputAmount}
+                      placeholder="Enter amount you want to unstake"
+                      type="number"
+                      autoFocus
+                    />
+                    {error && (
+                      <span className={classes.stakeWithdrawInputError}>
+                        {error}
+                      </span>
+                    )}
+                  </div>
+                  <div className={classes.stakeWithdrawPreviewWrapper}>
+                    <Typography
+                      className={classes.stakeWithdrawPreviewHeader}
+                      variant={"h6"}
+                    >
+                      You'll receive
                   </Typography>
-                  <Typography className={classes.stakeWithdrawPreviewText}>
-                    ${(inputAmount * price * secondPrice).toLocaleString()}
-                  </Typography>
-                </div>
-              </>
-            )}
+                    <Typography className={classes.stakeWithdrawPreviewText}>
+                      ${(inputAmount * price * secondPrice).toLocaleString()}
+                    </Typography>
+                  </div>
+                </>
+              )}
             <div className={classes.voteButtonWrapper}>
               {stakeOrWithdraw !== "Stake" && (
                 <span className={classes.unstakeWarningText}>


### PR DESCRIPTION
There is a bug when staking in the governance vault that causes the error "Invalid amount".
In my example, I had a float amount in my wallet, 14.23, and I could not deposit anything between 1 and 10
See an example with this bug:
[Video example URL](https://streamable.com/53rygz)



I have added parseFloat to the amount for both onStake and onUnstake functions and from my tests, it seems that this fixed the issue.

