### PR TITLE
Fixes staking string comparison bug

### DIFF
--- a/src/components/vote/modal/stakeModal.jsx
+++ b/src/components/vote/modal/stakeModal.jsx
@@ -436,7 +436,7 @@ const StakeWithdrawModal = ({
   };
 
   const onStake = () => {
-    if (inputAmount <= 0 || inputAmount > balance) {
+    if (parseFloat(inputAmount) <= 0 || parseFloat(inputAmount) > parseFloat(balance)) {
       setError("Invalid Amount!");
       return;
     }
@@ -457,7 +457,7 @@ const StakeWithdrawModal = ({
   };
 
   const onUnstake = () => {
-    if (inputAmount < 0 || inputAmount > staked) {
+    if (parseFloat(inputAmount) < 0 || parseFloat(inputAmount) > parseFloat(staked)) {
       setError("Invalid Amount!");
       return;
     }


### PR DESCRIPTION
Currently users are presented with an "Invalid Amount!" error when staking an input amount that is greater in **lexicographic** order compared to the amount staked. This should be compared numerically using floating point instead.