### PR TITLE
Remove "soon" tag from LINKPAD/LINKCHECK

### DIFF
--- a/src/components/header/modal/modal.jsx
+++ b/src/components/header/modal/modal.jsx
@@ -112,14 +112,12 @@ class RedirectModal extends Component {
               text="LINKPAD"
               to="/"
               disabled
-              tag="SOON"
             />
             <HeaderLink
               screenType="MOBILE"
               text="LINKCHECK"
               to="/"
               disabled
-              tag="SOON"
             />
             <HeaderLink
               screenType="MOBILE"

--- a/src/components/header/modal/modal.jsx
+++ b/src/components/header/modal/modal.jsx
@@ -78,12 +78,6 @@ class RedirectModal extends Component {
             />
             <HeaderLink
               screenType="MOBILE"
-              text="LINKSMAS"
-              to={"/linksmas-2020"}
-              selected={true}
-            />
-            <HeaderLink
-              screenType="MOBILE"
               text="LINKSWAP"
               to={"https://linkswap.app/"}
               externalLink={true}
@@ -102,22 +96,22 @@ class RedirectModal extends Component {
             />
             <HeaderLink
               screenType="MOBILE"
-              text="WAFFLEHOUSE"
-              to="/"
-              disabled
-              tag="SOON"
-            />
-            <HeaderLink
-              screenType="MOBILE"
               text="LINKPAD"
-              to="/"
-              disabled
+              to="https://blog.yflink.io/project-announcement-linkpad/"
+              externalLink={true}
             />
             <HeaderLink
               screenType="MOBILE"
               text="LINKCHECK"
+              to="https://blog.yflink.io/linkcheck/"
+              externalLink={true}
+            />
+            <HeaderLink
+              screenType="MOBILE"
+              text="WAFFLEHOUSE"
               to="/"
               disabled
+              tag="SOON"
             />
             <HeaderLink
               screenType="MOBILE"

--- a/src/components/initial/initial.jsx
+++ b/src/components/initial/initial.jsx
@@ -701,14 +701,6 @@ class Initial extends Component {
                     LINKPAD
                   </span>
                 </IconButton>
-                <div className={classes.comingSoonTagContainer}>
-                  <Typography
-                    variant="h6"
-                    className={classes.comingSoonTagText}
-                  >
-                    SOON
-                  </Typography>
-                </div>
               </div>
               <div className={classes.linkButtonDisabledWrapper}>
                 <IconButton
@@ -726,14 +718,6 @@ class Initial extends Component {
                     LINKCHECK
                   </span>
                 </IconButton>
-                <div className={classes.comingSoonTagContainer}>
-                  <Typography
-                    variant="h6"
-                    className={classes.comingSoonTagText}
-                  >
-                    SOON
-                  </Typography>
-                </div>
               </div>
             </div>
             <div className={classes.linkSwapToolsContainer}>

--- a/src/components/initial/initial.jsx
+++ b/src/components/initial/initial.jsx
@@ -343,6 +343,18 @@ const styles = (theme) => ({
       backgroundColor: "rgba(255, 255, 255, 0.2);",
     },
   },
+  linkSmallButton: {
+    width: "200px",
+    height: "48px",
+    borderRadius: "8px",
+    border: "solid 2px rgba(255, 255, 255, 1)",
+    "&:hover": {
+      backgroundColor: "rgba(255, 255, 255, 0.2);",
+    },
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "flex-start",
+  },
   linkDisabledButton: {
     width: "200px",
     height: "48px",
@@ -687,8 +699,10 @@ class Initial extends Component {
               </div>
               <div className={classes.linkButtonDisabledWrapper}>
                 <IconButton
-                  className={classes.linkDisabledButton}
-                  onClick={() => {}}
+                  className={classes.linkSmallButton}
+                  onClick={() => {
+                    window.open("https://blog.yflink.io/project-announcement-linkpad/");
+                  }}
                 >
                   <LinkpadIcon
                     style={{
@@ -704,8 +718,10 @@ class Initial extends Component {
               </div>
               <div className={classes.linkButtonDisabledWrapper}>
                 <IconButton
-                  className={classes.linkDisabledButton}
-                  onClick={() => {}}
+                  className={classes.linkSmallButton}
+                  onClick={() => {
+                    window.open("https://blog.yflink.io/linkcheck/");
+                  }}
                 >
                   <LinkcheckIcon
                     style={{


### PR DESCRIPTION
This PR removes the "soon" tag from LINKPAD/LINKCHECK buttons which now direct to the most relevant current blog posts. I have also tidied the modal links by removing LINKSMAS and re-ordering slightly.